### PR TITLE
Link to 'main' branch on Github as it's the default name these days

### DIFF
--- a/src/main/java/com/softwire/todos/SourceControlLinkFormatter.java
+++ b/src/main/java/com/softwire/todos/SourceControlLinkFormatter.java
@@ -16,7 +16,7 @@ public abstract class SourceControlLinkFormatter {
         }
 
         public String build(String file, int line) {
-            return String.format("%s/blob/master/%s#L%s", this.baseUrl, file, line);
+            return String.format("%s/blob/main/%s#L%s", this.baseUrl, file, line);
         }
     }
 


### PR DESCRIPTION
This changes the default link on Github to the "main" branch, because new Github repositories (and many existing ones) have a default branch called "main" not "master".

For Github projects which still have a default branch called "master" and no "main" branch, this link will [redirect](https://github.blog/changelog/2020-07-17-links-to-deleted-branches-now-redirect-to-the-default-branch/) to the correct place.

For Github projects which still have a default "master" branch _but_ which have also have a "main" branch, this will break/do the wrong thing. If you think that's an unacceptable cost then we should just close this PR and leave the behaviour as is.

I've also not changed it for Gitblit because as far as I can tell that doesn't have the concept of a default branch/I have no idea what the behaviour should be there.