### PR TITLE
Remove trailing comma in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= {
     "com.slack.api" % "slack-api-client" % "1.27.3",
     "args4j" % "args4j" % "2.33",
     "junit" % "junit" % "4.4" % Test,
-    "com.novocode" % "junit-interface" % "0.11" % Test exclude("junit", "junit-dep"),
+    "com.novocode" % "junit-interface" % "0.11" % Test exclude("junit", "junit-dep")
   )
 }
 


### PR DESCRIPTION
I just saw that this caused a build failure.  Looks like trailing commas have not always been supported.